### PR TITLE
Use python 3.11 for package version extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Set up Python 3.11+
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
     - name: Extract package version
       id: package-version
       run: |


### PR DESCRIPTION
In this MR we use Python 3.11 with `tomli` available
for the package version extraction.